### PR TITLE
Lock label creation

### DIFF
--- a/lib/Prometheus/Client/Metrics.pm6
+++ b/lib/Prometheus/Client/Metrics.pm6
@@ -282,8 +282,9 @@ class Group is export(:collectors) does Collector does Descriptor {
         with %!metrics{ $labels-key } {
             return $_;
         }
+        my $collector;
         $!label-adding-lock.protect: {
-            return %!metrics{ $labels-key } //= $.factory.build($.type,
+            $collector = %!metrics{ $labels-key } //= $.factory.build($.type,
                 :$.name,
                 :$.namespace,
                 :$.subsystem,
@@ -291,6 +292,7 @@ class Group is export(:collectors) does Collector does Descriptor {
                 :$.documentation,
             );
         };
+        return $collector;
     }
 
     method remove(*@label-values, *%labels --> Collector) {

--- a/t/memory-corruption.t
+++ b/t/memory-corruption.t
@@ -1,5 +1,16 @@
 #!/usr/bin/env raku
 
+{
+    CATCH {
+        default {
+            skip 'cannot trigger garbage collection';
+            done-testing
+            exit
+        }
+    }
+    VM.request-garbage-collection;
+}
+
 use Test;
 use Prometheus::Client :metrics;
 

--- a/t/memory-corruption.t
+++ b/t/memory-corruption.t
@@ -1,18 +1,19 @@
 #!/usr/bin/env raku
 
+use Test;
+use Prometheus::Client :metrics;
+
+plan 1;
+
 {
     CATCH {
         default {
             skip 'cannot trigger garbage collection';
-            done-testing
             exit
         }
     }
     VM.request-garbage-collection;
 }
-
-use Test;
-use Prometheus::Client :metrics;
 
 my $THREADS = 20;
 my $ROUNDS  = 2000;
@@ -44,5 +45,4 @@ my $ROUNDS  = 2000;
 VM.request-garbage-collection;
 
 pass 'no memory corruption when adding new labels';
-done-testing
 

--- a/t/memory-corruption.t
+++ b/t/memory-corruption.t
@@ -1,0 +1,37 @@
+#!/usr/bin/env raku
+
+use Test;
+use Prometheus::Client :metrics;
+
+my $THREADS = 20;
+my $ROUNDS  = 2000;
+
+{
+    my $metric1;
+
+    my $registry = METRICS {
+        $metric1 = counter(
+            name => 'm1',
+            documentation => 'doc',
+            label-names => ['label1']
+        );
+    };
+
+    my @workers = (^$THREADS).map: -> $num {
+        start {
+            for ^$ROUNDS -> $counter {
+                my $label1 = ($num + $THREADS * $counter).Str;
+                $metric1.labels(:$label1).inc;
+            }
+        }
+    };
+
+    await @workers;
+}
+
+
+VM.request-garbage-collection;
+
+pass 'no memory corruption when adding new labels';
+done-testing
+


### PR DESCRIPTION
The current way which labelled metrics are created is not thread safe and can cause memory corruption inside of MoarVM. See the corresponding [Rakudo issue](https://github.com/rakudo/rakudo/issues/3739) for details.
I am also contemplating using a [ReadWriteLock](https://modules.raku.org/dist/ReadWriteLock) instead to also protect read access.