### PR TITLE
properly collect metrics with labels

### DIFF
--- a/lib/Prometheus/Client/Metrics.pm6
+++ b/lib/Prometheus/Client/Metrics.pm6
@@ -238,7 +238,7 @@ class StateSet is export(:collectors) does Base {
 
 class Factory { ... }
 
-class Group is export(:collectors) does Base does Descriptor {
+class Group is export(:collectors) does Base {
     my class LabelsKey {
         has @.labels;
         method WHICH(--> ObjAt:D) {

--- a/lib/Prometheus/Client/Metrics.pm6
+++ b/lib/Prometheus/Client/Metrics.pm6
@@ -238,7 +238,7 @@ class StateSet is export(:collectors) does Base {
 
 class Factory { ... }
 
-class Group is export(:collectors) does Collector does Descriptor {
+class Group is export(:collectors) does Base does Descriptor {
     my class LabelsKey {
         has @.labels;
         method WHICH(--> ObjAt:D) {
@@ -294,23 +294,11 @@ class Group is export(:collectors) does Collector does Descriptor {
 
     method clear() { %!metrics = %() }
 
-    method describe(--> Seq:D) {
-        gather {
-            for %!metrics.values -> $metric {
-                take $_ for $metric.describe;
-            }
-        }
-    }
-
-    method collect(--> Seq:D) {
+    method samples(--> Seq:D) {
         gather {
             for %!metrics.kv -> $labels-key, $collector {
-                for $collector.collect -> $metric {
-                    for $metric.samples -> $sample {
-                        append $sample.labels, $labels-key.labels;
-                    }
-
-                    take $metric;
+                for $collector.samples -> ($suffix, @labels, $value) {
+                    take $suffix, (@labels.Slip, $labels-key.labels.Slip), $value;
                 }
             }
         }

--- a/t/labels.t
+++ b/t/labels.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env raku
+
+use Test;
+use Prometheus::Client :metrics;
+use Prometheus::Client::Exposition :render;
+
+plan 1;
+
+my $metric1;
+
+my $registry = METRICS {
+    $metric1 = gauge(
+        name => 'm1',
+        documentation => 'doc',
+        label-names => <label1 label2>
+    );
+};
+
+my $foo = $metric1.labels(:label1('a'), :label2('b'));
+$foo.set(pi);
+$metric1.labels(:label1('y'), :label2('z')).set(2*pi);
+
+#`( should be something like
+# HELP m1 doc
+# TYPE m1 gauge
+m1{label1="y",label2="z"} 6.283185307179586
+m1{label1="a",label2="b"} 3.141592653589793
+)
+
+like render-metrics($registry),
+    / ^
+        '# HELP m1 doc'\n
+        '# TYPE m1 gauge'\n
+        (
+            'm1{label'<[12]>'="'<[ab]>'",label'<[12]>'="'<[ab]>'"} 3.'\d+\n
+            |
+            'm1{label'<[12]>'="'<[yz]>'",label'<[12]>'="'<[yz]>'"} 6.'\d+\n
+        ) ** 2
+    $ /, 'expect meta data and two lines with labels and values';
+
+#diag render-metrics($registry);


### PR DESCRIPTION
## The Problem
The metric meta data should only be provided once for a given metric.
See the [Prometheus exposition formats documentation](https://prometheus.io/docs/instrumenting/exposition_formats/) and my Telegraf based scraper also complains.

## Expected Behavior
```
# HELP m1 doc
# TYPE m1 gauge
m1{label1="a",label2="b"} 3.141592653589793
m1{label1="y",label2="z"} 6.283185307179
```
## Actual Behavior
```
# HELP m1 doc
# TYPE m1 gauge
m1{label1="a",label2="b"} 3.141592653589793
# HELP m1 doc
# TYPE m1 gauge
m1{label1="y",label2="z"} 6.283185307179
```