### PR TITLE
improve render speed

### DIFF
--- a/lib/Prometheus/Client/Exposition.pm6
+++ b/lib/Prometheus/Client/Exposition.pm6
@@ -29,8 +29,9 @@ method render-timestamp(Sample:D $sample --> Str:D) {
     }
 }
 
+my %escape-cache;
 method escape-value(Str:D $s --> Str:D) {
-    $s.trans([ '"', '\\', "\n" ] => [ '\\"', '\\\\', '\\n' ]);
+    return %escape-cache{$s} //= $s.trans([ '"', '\\', "\n" ] => [ '\\"', '\\\\', '\\n' ]);
 }
 
 method render-labels(Sample:D $sample --> Str:D) {
@@ -41,18 +42,18 @@ method render-labels(Sample:D $sample --> Str:D) {
 }
 
 method render-sample(Sample:D $sample --> Str:D) {
-    [~] $sample.name,
+    ($sample.name,
         self.render-labels($sample),
         self.render-value($sample),
         self.render-timestamp($sample),
         "\n"
-        ;
+    ).join;
 }
 
 method render-samples(Metric:D $metric --> Str:D) {
-    [~] do for $metric.samples -> $sample {
+    $metric.samples.map( -> $sample {
         self.render-sample($sample);
-    }
+    }).join
 }
 
 method render-metric(Metric:D $metric --> Str:D) {
@@ -60,9 +61,9 @@ method render-metric(Metric:D $metric --> Str:D) {
 }
 
 method render(--> Str:D) {
-    [~] $.collector.collect.map: -> $metric {
+    $.collector.collect.map( -> $metric {
         self.render-metric($metric)
-    }
+    }).join;
 }
 
 sub render-metrics(Collector:D $collector --> Str:D) is export(:render) {


### PR DESCRIPTION
This changes improve the render speed of my benchmark script below by factor 3.
The biggest win is the cached escaped label values. The joins add another few percent.

```
use v6;
use Prometheus::Client :metrics;
use Prometheus::Client::Exposition :render;

my $counter;
my $start = now;
my $m = BEGIN METRICS {
    $counter = counter(
        name => 'm1',
        documentation => 'doc',
        label-names => <l1 l2 l3 l4>,
    );
}

for ^10000 -> $num {

    my ($l1, $l2, $l3, $l4) := ($num.Str) xx 4;
    $counter.labels(:$l1, :$l2, :$l3, :$l4).inc(pi);
}

my $start-render = now;
render-metrics($m);
my $done = now;

say "setup time:  {$start-render - $start}s";
say "render time: {$done - $start-render}s";
say "ratio:       {($done - $start-render) / ($start-render - $start)}";
```